### PR TITLE
Adding the status for each individual report 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bidu-house (0.1.2)
+    bidu-house (0.2.1)
       activesupport
       bidu-active_ext
       concern_builder
@@ -27,11 +27,11 @@ GEM
     bidu-active_ext (1.0.0)
       activesupport
       bidu-core_ext
-    bidu-core_ext (1.0.0)
+    bidu-core_ext (1.2.1)
       activesupport
     builder (3.2.2)
     coderay (1.1.0)
-    concern_builder (0.0.1)
+    concern_builder (0.0.2)
       activesupport
     diff-lcs (1.2.5)
     docile (1.1.5)

--- a/README.md
+++ b/README.md
@@ -63,3 +63,20 @@ with error and render the report
  wget http://localhost:3000/health-check/status?period=3.days&threshold=0.005
  wget http://localhost:3000/health-check/late-status?period=1.hours&threshold=0.1
  ```
+
+ 6. Use the status json to understand what is wrong
+ ```json
+ {
+   "status": "error",
+   "failures": {
+     "ids": [10, 14],
+     "percentage": 0.5,
+     "status": "error"
+   },
+   "delays": {
+     "ids": [12],
+     "percentage": 0.001,
+     "status": "ok"
+   }
+ }
+ ```

--- a/lib/bidu/house/report/error.rb
+++ b/lib/bidu/house/report/error.rb
@@ -35,13 +35,18 @@ module Bidu
         end
 
         def error?
-          percentage > threshold
+          @error ||= percentage > threshold
+        end
+
+        def status
+          error? ? :error : :ok
         end
 
         def as_json
           {
             ids: scoped.pluck(external_key),
-            percentage: percentage
+            percentage: percentage,
+            status: status
           }
         end
 

--- a/lib/bidu/house/version.rb
+++ b/lib/bidu/house/version.rb
@@ -1,5 +1,5 @@
 module Bidu
   module House
-    VERSION = '0.1.2'
+    VERSION = '0.2.1'
   end
 end

--- a/spec/lib/bidu/house/report/error_spec.rb
+++ b/spec/lib/bidu/house/report/error_spec.rb
@@ -293,6 +293,17 @@ describe Bidu::House::Report::Error do
     end
   end
 
+  describe '#status' do
+    context 'when errors percentage overcames threshold' do
+      it { expect(subject.status).to eq(:error) }
+    end
+
+    context 'when errors percentage does not overcames threshold' do
+      let(:errors) { 0 }
+      it { expect(subject.status).to eq(:ok) }
+    end
+  end
+
   describe '#as_json' do
     let(:expected) do
       { ids: ids_expected, percentage: percentage_expected, status: status_expected }

--- a/spec/lib/bidu/house/report/error_spec.rb
+++ b/spec/lib/bidu/house/report/error_spec.rb
@@ -299,7 +299,7 @@ describe Bidu::House::Report::Error do
       let(:successes) { 1 }
       let(:ids_expected) { [10, 11, 12] }
       let(:expected) do
-        { ids: ids_expected, percentage: 0.75 }
+        { ids: ids_expected, percentage: 0.75, status: :error }
       end
 
       it 'returns the external keys and error percentage' do

--- a/spec/lib/bidu/house/report/error_spec.rb
+++ b/spec/lib/bidu/house/report/error_spec.rb
@@ -294,15 +294,32 @@ describe Bidu::House::Report::Error do
   end
 
   describe '#as_json' do
+    let(:expected) do
+      { ids: ids_expected, percentage: percentage_expected, status: status_expected }
+    end
+
+    context 'when everything is ok' do
+      let(:errors) { 1 }
+      let(:successes) { 9 }
+      let(:ids_expected) { [90] }
+      let(:status_expected) { :ok }
+      let(:percentage_expected) { 0.1 }
+      let(:threshold) { 0.5 }
+
+      it 'returns the external keys, status and error percentage' do
+        expect(subject.as_json).to eq(expected)
+      end
+
+    end
+
     context 'when there are 75% erros' do
+      let(:status_expected) { :error }
+      let(:percentage_expected) { 0.75 }
       let(:errors) { 3 }
       let(:successes) { 1 }
       let(:ids_expected) { [10, 11, 12] }
-      let(:expected) do
-        { ids: ids_expected, percentage: 0.75, status: :error }
-      end
 
-      it 'returns the external keys and error percentage' do
+      it 'returns the external keys, status and error percentage' do
         expect(subject.as_json).to eq(expected)
       end
 

--- a/spec/lib/bidu/house/report_builder_spec.rb
+++ b/spec/lib/bidu/house/report_builder_spec.rb
@@ -37,7 +37,7 @@ describe Bidu::House::ReportBuilder do
     end
 
     it 'builds the report using the given configuration' do
-      expect(report.as_json).to eq( ids: ids, percentage: 0.25 )
+      expect(report.as_json).to eq( ids: ids, percentage: 0.25, status: :error )
       expect(report.error?).to be_truthy
     end
 
@@ -50,7 +50,7 @@ describe Bidu::House::ReportBuilder do
     end
 
     context 'when passing a custom period parameter' do
-      let(:parameters) { { threshold: 0.4, period: 10.days } }
+      let(:parameters) { { threshold: 0.4, period: 10.days, status: :error } }
 
       it 'uses custom period parameter' do
         expect(report.error?).to be_truthy
@@ -63,7 +63,7 @@ describe Bidu::House::ReportBuilder do
       end
 
       it 'ignores the non customizable parameters' do
-        expect(report.as_json).to eq( ids: ids, percentage: 0.25 )
+        expect(report.as_json).to eq( ids: ids, percentage: 0.25, status: :error )
         expect(report.error?).to be_truthy
         expect(report.id).to eq(:errors)
       end

--- a/spec/lib/bidu/house/status_builder_spec.rb
+++ b/spec/lib/bidu/house/status_builder_spec.rb
@@ -40,7 +40,8 @@ describe Bidu::House::StatusBuilder do
          status: status_expected,
          failures: {
            ids: ids,
-           percentage: percentage
+           percentage: percentage,
+           status: status_expected
          }
        }
     end

--- a/spec/lib/bidu/house/status_spec.rb
+++ b/spec/lib/bidu/house/status_spec.rb
@@ -98,7 +98,8 @@ describe Bidu::House::Status do
         status: :error,
         errors: {
           ids: ids,
-          percentage: 0.75
+          percentage: 0.75,
+          status: :error
         }
       }
     end
@@ -114,11 +115,13 @@ describe Bidu::House::Status do
           status: :error,
           errors: {
             ids: ids,
-            percentage: 0.75
+            percentage: 0.75,
+            status: :error
           },
           success: {
             ids: success_ids,
-            percentage: 0.25
+            percentage: 0.25,
+            status: :error
           }
         }
       end


### PR DESCRIPTION
This report adds, to the final json, the status for each report
#### Before

``` json
{
  "status": "error",
  "last_failures": {
    "ids": [],
    "percentage": ​0.0
  },
  "late": {
    "ids": [ 10, 105, 30 ],
    "percentage": ​0.5
  }
}
```
#### After

``` json
{
  "status": "error",
  "last_failures": {
    "ids": [],
    "status": "error",
    "percentage": ​0.0
  },
  "late": {
    "ids": [ 10, 105, 30 ],
    "status": "error",
    "percentage": ​0.5
  }
}
```
