### PR TITLE
Uniq Ids report

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ with error and render the report
  - threshold: default report threshold (default: 0.02)
  - period: default search period (default: 1 day)
  - on: report bucket (default: :default)
+ - base_scope: scope to be universal sample
+ - uniq: when the output ids should not be repeated
+ - limit: limit of ids to be outputed
 
 4. Run the server and hit the health-check routes
 

--- a/lib/bidu/house/report/error.rb
+++ b/lib/bidu/house/report/error.rb
@@ -10,7 +10,7 @@ module Bidu
 
         json_parse :threshold, type: :float
         json_parse :period, type: :period
-        json_parse :scope, :id, :clazz, :base_scope, :external_key, :uniq, case: :snake
+        json_parse :scope, :id, :clazz, :base_scope, :external_key, :uniq, :limit, case: :snake
 
         def initialize(options)
           @json = {
@@ -56,6 +56,8 @@ module Bidu
         def ids
           relation = scoped
           relation = relation.uniq if uniq
+          relation = relation.limit(limit) if limit
+
           relation.pluck(external_key)
         end
 

--- a/lib/bidu/house/report/error.rb
+++ b/lib/bidu/house/report/error.rb
@@ -10,7 +10,7 @@ module Bidu
 
         json_parse :threshold, type: :float
         json_parse :period, type: :period
-        json_parse :scope, :id, :clazz, :base_scope, :external_key, case: :snake
+        json_parse :scope, :id, :clazz, :base_scope, :external_key, :uniq, case: :snake
 
         def initialize(options)
           @json = {
@@ -18,7 +18,8 @@ module Bidu
             threshold: 0.02,
             period: 1.day,
             scope: :with_error,
-            base_scope: :all
+            base_scope: :all,
+            uniq: false
           }.merge(options)
         end
 
@@ -44,13 +45,19 @@ module Bidu
 
         def as_json
           {
-            ids: scoped.pluck(external_key),
+            ids: ids,
             percentage: percentage,
             status: status
           }
         end
 
         private
+
+        def ids
+          relation = scoped
+          relation = relation.uniq if uniq
+          relation.pluck(external_key)
+        end
 
         def fetch_percentage
           if (scope.is_a?(Symbol))

--- a/spec/lib/bidu/house/report/error_spec.rb
+++ b/spec/lib/bidu/house/report/error_spec.rb
@@ -341,24 +341,32 @@ describe Bidu::House::Report::Error do
         it 'returns the correct external keys' do
           expect(subject.as_json).to eq(expected)
         end
-      end
 
-      context 'when some external ids are the same' do
-        let(:external_key) { :outter_external_id }
-        let(:ids_expected) { [10, 10, 10] }
-        before do
-          Document.update_all(outter_external_id: 10) 
+        context 'when some external ids are the same' do
+          let(:ids_expected) { [10, 10, 10] }
+          before do
+            Document.update_all(outter_external_id: 10)
+          end
+
+          it 'returns the correct external keys' do
+            expect(subject.as_json).to eq(expected)
+          end
+
+          context 'and passing uniq option' do
+            before { options[:uniq] = true }
+            let(:ids_expected) { [10] }
+
+            it 'returns the correct external keys only once' do
+              expect(subject.as_json).to eq(expected)
+            end
+          end
         end
 
-        it 'returns the correct external keys' do
-          expect(subject.as_json).to eq(expected)
-        end
+        context 'with a limit' do
+          before { options[:limit] = 2 }
+          let(:ids_expected) { [0, 1] }
 
-        context 'and passing uniq option' do
-          before { options[:uniq] = true }
-          let(:ids_expected) { [10] }
-
-          it 'returns the correct external keys only once' do
+          it 'returns only the limited ids' do
             expect(subject.as_json).to eq(expected)
           end
         end

--- a/spec/lib/bidu/house/report/error_spec.rb
+++ b/spec/lib/bidu/house/report/error_spec.rb
@@ -343,6 +343,27 @@ describe Bidu::House::Report::Error do
         end
       end
 
+      context 'when some external ids are the same' do
+        let(:external_key) { :outter_external_id }
+        let(:ids_expected) { [10, 10, 10] }
+        before do
+          Document.update_all(outter_external_id: 10) 
+        end
+
+        it 'returns the correct external keys' do
+          expect(subject.as_json).to eq(expected)
+        end
+
+        context 'and passing uniq option' do
+          before { options[:uniq] = true }
+          let(:ids_expected) { [10] }
+
+          it 'returns the correct external keys only once' do
+            expect(subject.as_json).to eq(expected)
+          end
+        end
+      end
+
       context 'when configurated without external key' do
         before { options.delete(:external_key) }
         let(:ids_expected) { Document.with_error.where('created_at > ?', 30.hours.ago).map(&:id) }


### PR DESCRIPTION
This PR makes possible to alter configuration and pass new parameters for the id report:
- Uniq (don't repeat ids)
- Limit (Output a max id size)
